### PR TITLE
Fix release generation

### DIFF
--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -45,8 +45,11 @@ main() {
     esac
     [ -n "${version}" ] || err "Not building a release"
 
-    git show --pretty= --name-only "${GITHUB_REF}" \
-        | xargs tar czf rules_shtk-"${version}".tar.gz
+    local distname="rules_shtk-${version}"
+    mkdir "${distname}"
+    git ls-tree --name-only -r "${GITHUB_REF}" \
+        | xargs tar -cf - | tar -C "${distname}" -xf -
+    tar czf "${distname}.tar.gz" "${distname}"
 }
 
 main


### PR DESCRIPTION
Make sure to put the release files within a directory named after the release, and fix the command used to gather all files to place inside of the release.