### PR TITLE
Add missing tests for bad arguments

### DIFF
--- a/examples/test/adder.c
+++ b/examples/test/adder.c
@@ -35,7 +35,6 @@
 // unittest module can be used to validate any program.
 //
 
-
 #include <err.h>
 #include <errno.h>
 #include <inttypes.h>

--- a/examples/test/adder_test.sh
+++ b/examples/test/adder_test.sh
@@ -87,3 +87,14 @@ bad_second_operand_test() {
         -e inline:"adder: Invalid second operand: out of range\n" \
         ../adder 0 -123456789
 }
+
+
+shtk_unittest_add_test bad_arguments
+bad_arguments_test() {
+    expect_command \
+        -s 1 -e inline:"adder: Requires two integer arguments\n" ../adder
+    expect_command \
+        -s 1 -e inline:"adder: Requires two integer arguments\n" ../adder 1
+    expect_command \
+        -s 1 -e inline:"adder: Requires two integer arguments\n" ../adder 1 2 3
+}


### PR DESCRIPTION
Extend the examples/test demo test program to validate that the adder binary correctly errors out when the number of arguments given to it is wrong.