### PR TITLE
Improve error handling when system toolchain is not found.

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -38,9 +38,10 @@ SHTK_SHA256 = "9386b7dbf1a28361eaf56dd1712385abdbdf3a02f03e17ccbf5579bf22695e27"
 def _shtk_autoconf_toolchain_impl(repository_ctx):
     shtk_path = repository_ctx.attr.shtk_path
     if not shtk_path:
-        shtk_path = str(repository_ctx.which("shtk"))
-    if not shtk_path:
-        fail("shtk cannot be found in the PATH")
+        path = repository_ctx.which("shtk")
+        if not path:
+            fail("shtk cannot be found in the PATH")
+        shtk_path = str(path)
 
     result = repository_ctx.execute([shtk_path, "version"])
     if result.return_code != 0:


### PR DESCRIPTION
The call to `which()` returns `None` if not found, but that became `str(None)` which evalutes as `True`, bypassing the cleaner error handling and leading to an ugly error from `execute()`.